### PR TITLE
Fixed the behavior of `ShortestPath` when the target vertex is not reachable from one of the visited vertices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2022-10-15
+
+### Added
+
 ## [0.12.0] - 2022-09-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+### Fixed
+* Fixed the behavior of `ShortestPath` when the target vertex is not reachable from one of the visited vertices.
+
 ## [0.12.0] - 2022-09-19
 
 ### Added

--- a/paths.go
+++ b/paths.go
@@ -75,6 +75,10 @@ func CreatesCycle[K comparable, T any](g Graph[K, T], source, target K) (bool, e
 func ShortestPath[K comparable, T any](g Graph[K, T], source, target K) ([]K, error) {
 	weights := make(map[K]float64)
 	visited := make(map[K]bool)
+
+	// bestPredecessors stores the best (i.e. cheapest or least-weighted) predecessor for each
+	// vertex. If there is an edge AC with weight 4 and an edge BC with weight 2, the best
+	// predecessor for C is B.
 	bestPredecessors := make(map[K]K)
 
 	weights[source] = 0
@@ -128,6 +132,11 @@ func ShortestPath[K comparable, T any](g Graph[K, T], source, target K) ([]K, er
 	hashCursor := target
 
 	for hashCursor != source {
+		// If hashCursor is not a present key in bestPredecessors, hashCursor is set to the zero
+		// value. Without this check, this leads to endless prepending of zeros to the path.
+		if _, ok := bestPredecessors[hashCursor]; !ok {
+			return nil, fmt.Errorf("vertex %v is not reachable from vertex %v", target, source)
+		}
 		hashCursor = bestPredecessors[hashCursor]
 		path = append([]K{hashCursor}, path...)
 	}

--- a/paths_test.go
+++ b/paths_test.go
@@ -216,6 +216,17 @@ func TestDirectedShortestPath(t *testing.T) {
 			expectedShortestPath: []string{},
 			shouldFail:           true,
 		},
+		"target not reachable connected directed graph": {
+			vertices: []string{"A", "B", "C"},
+			edges: []Edge[string]{
+				{Source: "A", Target: "B", Properties: EdgeProperties{Weight: 0}},
+				{Source: "A", Target: "C", Properties: EdgeProperties{Weight: 0}},
+			},
+			sourceHash:           "B",
+			targetHash:           "C",
+			expectedShortestPath: []string{},
+			shouldFail:           true,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Fixed the behavior of `ShortestPath` when the target vertex is not reachable from one of the visited vertices.